### PR TITLE
Change single colon to double colons for pseudo-elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ i {
 }
 
 // output
-i:before {
+i::before {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   font-family: iconmoon;
@@ -189,7 +189,7 @@ i:before {
 i.replaceIcon {
     font-size: 0;
 }
-i.replaceIcon:before {
+i.replaceIcon::before {
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
     font-family: iconmoon;
@@ -403,13 +403,13 @@ div {
 // output
 
 div {
-  &:before,
-  &:after {
+  &::before,
+  &::after {
     content: ' ';
     display: table;
   }
 
-  &:after {
+  &::after {
     clear: both;
   }
 }

--- a/src/mixins/_clearfix.scss
+++ b/src/mixins/_clearfix.scss
@@ -1,12 +1,12 @@
 @mixin clearfix {
 
-  &:before,
-  &:after {
+  &::before,
+  &::after {
     content: ' ';
     display: table;
   }
 
-  &:after {
+  &::after {
     clear: both;
   }
 

--- a/src/mixins/_icons.scss
+++ b/src/mixins/_icons.scss
@@ -1,6 +1,6 @@
-$iconFamily: 'fontawesome' !default;
-$iconPrefix: 'icon-' !default;
-$iconFamilyClass: '.fa' !default;
+$iconFamily: "fontawesome" !default;
+$iconPrefix: "icon-" !default;
+$iconFamilyClass: ".fa" !default;
 
 @mixin icon($icon, $position, $replace: false) {
   @if $replace {
@@ -10,9 +10,9 @@ $iconFamilyClass: '.fa' !default;
   @if (variable-exist(iconFamilyClass)) {
     @extend #{$iconFamilyClass};
   }
-  
-  &:#{$position} {
-    @extend .#{$iconPrefix}#{$icon}:before !optional;
+
+  &::#{$position} {
+    @extend .#{$iconPrefix}#{$icon}::before !optional;
 
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements

> Note: As a rule, double colons (::) should be used instead of a single colon (:). This distinguishes pseudo-classes from pseudo-elements. However, since this distinction was not present in older versions of the W3C spec, most browsers support both syntaxes for the original pseudo-elements.
